### PR TITLE
Address identified security gaps

### DIFF
--- a/pypi_query_mcp/core/pypi_client.py
+++ b/pypi_query_mcp/core/pypi_client.py
@@ -42,9 +42,12 @@ class PyPIClient:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
 
-        # Simple in-memory cache
-        self._cache: dict[str, dict[str, Any]] = {}
+        # Simple in-memory cache with size limit
+        from collections import OrderedDict
+
+        self._cache: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
         self._cache_ttl = 300  # 5 minutes
+        self._cache_size_limit = 100
 
         # HTTP client configuration
         self._client = httpx.AsyncClient(
@@ -200,6 +203,8 @@ class PyPIClient:
             # Cache the result
             import time
 
+            if len(self._cache) >= self._cache_size_limit:
+                self._cache.popitem(last=False)
             self._cache[cache_key] = {"data": data, "timestamp": time.time()}
 
             return data

--- a/pypi_query_mcp/core/stats_client.py
+++ b/pypi_query_mcp/core/stats_client.py
@@ -40,9 +40,12 @@ class PyPIStatsClient:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
 
-        # Simple in-memory cache
-        self._cache: dict[str, dict[str, Any]] = {}
+        # Simple in-memory cache with size limit
+        from collections import OrderedDict
+
+        self._cache: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
         self._cache_ttl = 3600  # 1 hour (data updates daily)
+        self._cache_size_limit = 100
 
         # HTTP client configuration
         self._client = httpx.AsyncClient(
@@ -200,6 +203,8 @@ class PyPIStatsClient:
             # Cache the result
             import time
 
+            if len(self._cache) >= self._cache_size_limit:
+                self._cache.popitem(last=False)
             self._cache[cache_key] = {"data": data, "timestamp": time.time()}
 
             return data

--- a/pypi_query_mcp/tools/dependency_resolver.py
+++ b/pypi_query_mcp/tools/dependency_resolver.py
@@ -18,6 +18,8 @@ class DependencyResolver:
     """Resolves package dependencies recursively."""
 
     def __init__(self, max_depth: int = 10):
+        if max_depth < 1 or max_depth > 10:
+            raise ValueError("max_depth must be between 1 and 10")
         self.max_depth = max_depth
         self.parser = DependencyParser()
         self.resolved_cache: dict[str, dict[str, Any]] = {}
@@ -45,7 +47,9 @@ class DependencyResolver:
         if not package_name or not package_name.strip():
             raise InvalidPackageNameError(package_name)
 
-        max_depth = max_depth or self.max_depth
+        max_depth = self.max_depth if max_depth is None else max_depth
+        if max_depth < 1 or max_depth > 10:
+            raise ValueError("max_depth must be between 1 and 10")
         include_extras = include_extras or []
 
         logger.info(

--- a/pypi_query_mcp/tools/package_downloader.py
+++ b/pypi_query_mcp/tools/package_downloader.py
@@ -224,14 +224,21 @@ class PackageDownloader:
 
         url = file_info.get("url")
         filename = file_info.get("filename")
-        expected_md5 = file_info.get("md5_digest")
+        expected_sha256 = (
+            file_info.get("digests", {}).get("sha256")
+            or file_info.get("sha256_digest")
+        )
         expected_size = file_info.get("size")
 
         if not url or not filename:
             raise ValueError("Invalid file info: missing URL or filename")
 
-        # Create package-specific directory
-        file_path = self.download_dir / filename
+        # Sanitize filename to prevent path traversal
+        safe_name = Path(filename).name
+        file_path = (self.download_dir / safe_name).resolve()
+        download_dir_resolved = self.download_dir.resolve()
+        if not str(file_path).startswith(str(download_dir_resolved)):
+            raise ValueError("Invalid filename")
 
         logger.info(f"Downloading {filename} from {url}")
 
@@ -241,22 +248,22 @@ class PackageDownloader:
 
                 # Download with progress tracking
                 downloaded_size = 0
-                md5_hash = hashlib.md5()
+                sha256_hash = hashlib.sha256()
 
                 with open(file_path, "wb") as f:
                     async for chunk in response.aiter_bytes(chunk_size=8192):
                         f.write(chunk)
                         downloaded_size += len(chunk)
                         if verify_checksums:
-                            md5_hash.update(chunk)
+                            sha256_hash.update(chunk)
 
         # Verify download
         verification_result = {}
-        if verify_checksums and expected_md5:
-            actual_md5 = md5_hash.hexdigest()
-            verification_result["md5_match"] = actual_md5 == expected_md5
-            verification_result["expected_md5"] = expected_md5
-            verification_result["actual_md5"] = actual_md5
+        if verify_checksums and expected_sha256:
+            actual_sha256 = sha256_hash.hexdigest()
+            verification_result["sha256_match"] = actual_sha256 == expected_sha256
+            verification_result["expected_sha256"] = expected_sha256
+            verification_result["actual_sha256"] = actual_sha256
 
         if expected_size:
             verification_result["size_match"] = downloaded_size == expected_size
@@ -264,7 +271,7 @@ class PackageDownloader:
             verification_result["actual_size"] = downloaded_size
 
         return {
-            "filename": filename,
+            "filename": safe_name,
             "file_path": str(file_path),
             "downloaded_size": downloaded_size,
             "verification": verification_result,

--- a/tests/test_dependency_resolver.py
+++ b/tests/test_dependency_resolver.py
@@ -123,6 +123,27 @@ class TestDependencyResolver:
 
             assert result["summary"]["max_depth"] <= 1
 
+    def test_invalid_max_depth_init(self):
+        """Ensure invalid max depth values raise errors on init."""
+        with pytest.raises(ValueError):
+            DependencyResolver(max_depth=0)
+        with pytest.raises(ValueError):
+            DependencyResolver(max_depth=11)
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_depth_argument(self, resolver):
+        """Ensure invalid max depth values raise errors at runtime."""
+        with patch("pypi_query_mcp.core.PyPIClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get_package_info.return_value = {
+                "info": {"name": "test", "version": "1.0.0", "requires_dist": []}
+            }
+            with pytest.raises(ValueError):
+                await resolver.resolve_dependencies("test", max_depth=0)
+            with pytest.raises(ValueError):
+                await resolver.resolve_dependencies("test", max_depth=11)
+
     @pytest.mark.asyncio
     async def test_resolve_package_dependencies_function(self):
         """Test the standalone resolve_package_dependencies function."""

--- a/tests/test_package_downloader.py
+++ b/tests/test_package_downloader.py
@@ -2,6 +2,7 @@
 
 import shutil
 import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, mock_open, patch
 
 import pytest
@@ -223,6 +224,39 @@ class TestPackageDownloader:
                 )
 
                 assert result["python_version"] == "3.10"
+
+    @pytest.mark.asyncio
+    async def test_download_file_sanitizes_filename(self, downloader):
+        """Ensure filename is sanitized to prevent path traversal."""
+        file_info = {
+            "filename": "../../evil.whl",
+            "url": "https://example.com/evil.whl",
+            "digests": {"sha256": "a" * 64},
+            "size": 4,
+        }
+        with patch("httpx.AsyncClient") as mock_httpx_class:
+            mock_client = AsyncMock()
+            mock_httpx_class.return_value.__aenter__.return_value = mock_client
+            mock_response = AsyncMock()
+            mock_response.raise_for_status.return_value = None
+            async def _aiter_bytes(chunk_size=8192):
+                yield b"test"
+            mock_response.aiter_bytes = _aiter_bytes
+
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def fake_stream(*args, **kwargs):
+                yield mock_response
+
+            mock_client.stream = fake_stream
+
+            with patch("builtins.open", mock_open()) as m:
+                result = await downloader._download_file(file_info)
+
+                assert Path(result["file_path"]).parent == Path(downloader.download_dir).resolve()
+                assert result["filename"] == "evil.whl"
+                m.assert_called()
 
     @pytest.mark.asyncio
     async def test_download_package_with_dependencies_function(self, temp_download_dir):


### PR DESCRIPTION
## Summary
- limit memory caches in PyPI and statistics clients
- sanitize filenames and switch to SHA‑256 verification in package downloader
- validate dependency resolver depth
- add regression tests for new checks
- fix duplicate cache eviction check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e522535588327a6ebb3d53ba03e05